### PR TITLE
fix notification URL

### DIFF
--- a/app/Console/Commands/SendNotifications.php
+++ b/app/Console/Commands/SendNotifications.php
@@ -83,7 +83,7 @@ class SendNotifications extends Command
                         // Space
                         $txt .= ' &nbsp; - &nbsp; ';
                         // Clause
-                        $txt .= '<a href="' . url('/alice/' . $control->measure_id) . '">'. htmlentities($control->clause) . '</a>';
+                        $txt .= '<a href="' . url('/alice/show/' . $control->measure_id) . '">'. htmlentities($control->clause) . '</a>';
                         // Space
                         $txt .= ' &nbsp; - &nbsp; ';
                         // Name


### PR DESCRIPTION
There has been an error in the URL so it wouldn't resolve to a valid URL after clikcing on the link in the Email notification.