### PR TITLE
fix the planning date in the action plans summary screen

### DIFF
--- a/app/Http/Controllers/ActionplanController.php
+++ b/app/Http/Controllers/ActionplanController.php
@@ -26,7 +26,7 @@ class ActionplanController extends Controller
                     c1.score,
                     c1.name,
                     c1.scope,
-                    c2.plan_date,
+                    c1.plan_date,
                     c2.id as next_id,
                     c2.plan_date as next_date
                 from


### PR DESCRIPTION
The planning date displayed in the action plans summary screen is currently not correct, even though the link is correct. The reason is due to a small typo in the SQL query selecting the data.