### PR TITLE
fix the saving of the review date in the ActionplanController

### DIFF
--- a/app/Http/Controllers/ActionplanController.php
+++ b/app/Http/Controllers/ActionplanController.php
@@ -57,8 +57,13 @@ class ActionplanController extends Controller
         // save control
         $control = Control::find($id);
         $control->action_plan = request('action_plan');
-        $control->plan_date = request('plan_date');
         $control->update();
+        
+        // save next control
+        $next_id = $control->next_id;
+        $next_control = Control::find($next_id);
+        $next_control->plan_date = request('plan_date');
+        $next_control->update();
 
         return redirect('/actions');
     }


### PR DESCRIPTION
When modifying an action plan, one can modify the review date. The review date is actually the plan date of the next control, and not of the active control. Therefore, when saving the review date, one needs to load the next control, and then save the plan date of the next control.