### PR TITLE
Fix typo in french Lng

### DIFF
--- a/resources/lang/fr/cruds.php
+++ b/resources/lang/fr/cruds.php
@@ -30,7 +30,7 @@ return [
             'action_plan' => 'Plan d\'actions',
             'reference' => 'Ref',
             'type' => 'Type',
-            'due_date' => 'Date due',
+            'due_date' => 'Date d\'échéance',
             'choose_type' => 'Choisir un type',
             'choose_scope' => 'Choisir un périmètre',
             'remediation' => 'Remédiation',


### PR DESCRIPTION
Hi Didier, 

in Action plan, "Due Date" is translated to "Date due". I suggest "Date d'échéance"

Best regard