### PR TITLE
remove maxfilesize in DropZone

### DIFF
--- a/resources/views/controls/edit.blade.php
+++ b/resources/views/controls/edit.blade.php
@@ -264,8 +264,6 @@ const myDropzone = new Dropzone("div#dropzoneFileUpload", {
 	    url: '/doc/store',
 	    headers: { 'x-csrf-token': '{{csrf_token()}}'},
         params: function params(files, xhr, chunk) { return { 'control': '{{ $control->id }}' }; },
-	    maxFilesize: 10,
-	    // acceptedFiles: ".jpeg,.jpg,.png,.gif",
 	    addRemoveLinks: true,
 	    timeout: 50000,
 	    removedfile: function(file)

--- a/resources/views/controls/make.blade.php
+++ b/resources/views/controls/make.blade.php
@@ -288,8 +288,6 @@ document.addEventListener('DOMContentLoaded', function () {
         url: '/doc/store',
 	    headers: { 'x-csrf-token': '{{csrf_token()}}' },
         params: function params(files, xhr, chunk) { return { 'control': '{{ $control->id }}' }; },
-        maxFilesize: 10,
-        // acceptedFiles: ".jpeg,.jpg,.png,.gif",
         addRemoveLinks: true,
         timeout: 50000,
         removedfile: function(file)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Increased upload flexibility by removing the per-file size limit, allowing larger files to be uploaded.
  - Relaxed file type restrictions in the edit flow, enabling more formats to be uploaded.
- Notes
  - Upload behavior in creation flows remains functionally the same for file types, but now supports larger files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->