### PR TITLE
fix monday local

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -19,6 +19,15 @@
     }
     </style>
     @endif
+    {{-- Metro UI Calendar: start week on Monday for European --}}
+    <script>
+        (function() {
+            const weekStart = {{ in_array(app()->getLocale(), ['fr', 'de']) ? 1 : 0 }};
+            window.metroCalendarPickerSetup = { weekStart: weekStart };
+            window.metroCalendarSetup = { weekStart: weekStart };
+        })();
+    </script>
+
 </head>
 <body class="cloak">
 @if (!app()->environment('production'))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar components now respect locale-specific week start settings, automatically displaying the appropriate first day of the week based on user location (Monday for French and German locales, Sunday for others).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->