### PR TITLE
Gestion décodage JWT fix #596

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,5 +106,8 @@ OIDC_CLIENT_ID=deming
 OIDC_CLIENT_SECRET=deming
 OIDC_BASE_URL=http://auth.lan
 OIDC_SUFFIX=""
+OIDC_USE_ID_TOKEN=false     # true pour décoder le JWT
+OIDC_JWT_ALG=RS256          # RS256 ou HS256. utile uniquement avec OIDC_USE_ID_TOKEN=true
+OIDC_JWT_SECRET_OR_KEY=""   # secret pour HS256 ou clé au format PEM pour RS256
 OIDC_REDIRECT_URI=${APP_URL}auth/callback/oidc
 APP_VERSION=2025.08.13

--- a/app/Providers/Socialite/GenericSocialiteProvider.php
+++ b/app/Providers/Socialite/GenericSocialiteProvider.php
@@ -189,6 +189,20 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
             throw new \Exception('Failed to decode ID token: '.$e->getMessage(), 0, $e);
         }
 
-        return json_decode(json_encode($decoded), true);
+        $claims = (array) $decoded;
+        $clientId = config('services.oidc.client_id');
+        $expectedIssuer = rtrim(config('services.oidc.issuer', $this->getOIDCUrl()), '/');
+        $aud = $claims['aud'] ?? null;
+        $audiences = is_array($aud) ? $aud : ($aud !== null ? [$aud] : []);
+        if (($claims['iss'] ?? null) !== $expectedIssuer) {
+            throw new \Exception('Invalid ID token issuer');
+        }
+        if (!in_array($clientId, $audiences, true)) {
+            throw new \Exception('Invalid ID token audience');
+        }
+        if (count($audiences) > 1 && ($claims['azp'] ?? null) !== $clientId) {
+            throw new \Exception('Invalid ID token authorized party');
+        }
+        return $claims;
     }
 }

--- a/app/Providers/Socialite/GenericSocialiteProvider.php
+++ b/app/Providers/Socialite/GenericSocialiteProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Socialite;
 
 use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Arr;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\User;
@@ -42,7 +43,6 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
      * {@inheritdoc}
      */
     protected $scopeSeparator = ' ';
-    protected $idToken;
 
     /**
      * Return provider Url.
@@ -99,18 +99,26 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
         return $this->getOIDCUrl() . '/token';
     }
 
-    /**
-     * Get the access token response for the given code.
-     *
-     * @param  string  $code
-     * @return mixed
+   /**
+     * {@inheritdoc}
      */
-    public function getAccessTokenResponse($code)
+    public function user()
     {
-        $response = parent::getAccessTokenResponse($code);
-        $this->idToken = $response['id_token'] ?? null;
-        return $response;
+        if ($this->user) {
+            return $this->user;
+        }
+
+        if ($this->hasInvalidState()) {
+            throw new InvalidStateException;
+        }
+
+        $response = $this->getAccessTokenResponse($this->getCode());
+
+        $user = $this->getUserByToken(Arr::get($response, 'access_token'), Arr::get($response, 'id_token'));
+
+        return $this->userInstance($response, $user);
     }
+
 
     /**
      * @param string $token
@@ -119,15 +127,15 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
      *
      * @return array|mixed
      */
-    protected function getUserByToken($token)
+    protected function getUserByToken($token, $idToken = null)
     {
         $useIdToken = config('services.oidc.use_id_token', false);
 
         if ($useIdToken) {
-            if (!$this->idToken) {
+            if (!$idToken) {
                 throw new \Exception('OIDC_USE_ID_TOKEN=true but id_token not received');
             }
-            return $this->decodeIdToken($this->idToken);
+            return $this->decodeIdToken($idToken);
         }
 
         $base_url = $this->getOIDCUrl() . '/userinfo';

--- a/app/Providers/Socialite/GenericSocialiteProvider.php
+++ b/app/Providers/Socialite/GenericSocialiteProvider.php
@@ -6,6 +6,8 @@ use GuzzleHttp\Exception\GuzzleException;
 use Laravel\Socialite\Two\AbstractProvider;
 use Laravel\Socialite\Two\ProviderInterface;
 use Laravel\Socialite\Two\User;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Log;
 
 /**
@@ -40,6 +42,7 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
      * {@inheritdoc}
      */
     protected $scopeSeparator = ' ';
+    protected $idToken;
 
     /**
      * Return provider Url.
@@ -97,6 +100,19 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
     }
 
     /**
+     * Get the access token response for the given code.
+     *
+     * @param  string  $code
+     * @return mixed
+     */
+    public function getAccessTokenResponse($code)
+    {
+        $response = parent::getAccessTokenResponse($code);
+        $this->idToken = $response['id_token'] ?? null;
+        return $response;
+    }
+
+    /**
      * @param string $token
      *
      * @throws GuzzleException
@@ -105,6 +121,15 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
      */
     protected function getUserByToken($token)
     {
+        $useIdToken = config('services.oidc.use_id_token', false);
+
+        if ($useIdToken) {
+            if (!$this->idToken) {
+                throw new \Exception('OIDC_USE_ID_TOKEN=true but id_token not received');
+            }
+            return $this->decodeIdToken($this->idToken);
+        }
+
         $base_url = $this->getOIDCUrl() . '/userinfo';
         // If userinfo endpoint set, use it instead
         if (config('services.oidc.userinfo_endpoint')) {
@@ -139,5 +164,23 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
             $socialite_user[$socialite_attr] = $user[$provider_attr];
         }
         return (new User())->setRaw($user)->map($socialite_user);
+    }
+
+    protected function decodeIdToken($idToken)
+    {
+        $alg = config('services.oidc.jwt_alg', 'RS256');
+        $key = config('services.oidc.jwt_secret_or_key');
+
+        if (!$key) {
+            throw new \Exception('JWT secret or public key not configured');
+        }
+
+        try {
+            $decoded = JWT::decode($idToken, new Key($key, $alg));
+        } catch (\Exception $e) {
+            throw new \Exception('Failed to decode ID token: '.$e->getMessage(), 0, $e);
+        }
+
+        return json_decode(json_encode($decoded), true);
     }
 }

--- a/app/Providers/Socialite/GenericSocialiteProvider.php
+++ b/app/Providers/Socialite/GenericSocialiteProvider.php
@@ -109,7 +109,7 @@ class GenericSocialiteProvider extends AbstractProvider implements ProviderInter
         }
 
         if ($this->hasInvalidState()) {
-            throw new InvalidStateException;
+            throw new \Laravel\Socialite\Two\InvalidStateException;;
         }
 
         $response = $this->getAccessTokenResponse($this->getCode());

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPLv3",
     "require": {
         "php": "^8.2",
+        "firebase/php-jwt": "^7.0",
         "directorytree/ldaprecord-laravel": "^3.4",
         "erusev/parsedown": "^1.7",
         "laravel/framework": "^11.9",

--- a/config/services.php
+++ b/config/services.php
@@ -71,6 +71,9 @@ return [
         'authorize_endpoint' => env('OIDC_AUTHORIZE_ENDPOINT', null),
         'token_endpoint' => env('OIDC_TOKEN_ENDPOINT', null),
         'userinfo_endpoint' => env('OIDC_USERINFO_ENDPOINT', null),
+        'use_id_token' => env('OIDC_USE_ID_TOKEN', false),
+        'jwt_alg' => env('OIDC_JWT_ALG', 'RS256'),
+        'jwt_secret_or_key' => env('OIDC_JWT_SECRET_OR_KEY', ''),
         'map_user_attr' => [
             'id' => 'sub',
             'name' => 'name',


### PR DESCRIPTION
Bonjour,

Ce PR ajoute la possibilité de configurer Deming pour utiliser le id_token (JWT) retourné par l'IdP afin d'en extraire directement les claims, au lieu d'appeler l'endpoint /userinfo.

Cette fonctionnalité est utile avec Apereo CAS, qui ne fournit pas l'endpoint /userinfo.

Le fonctionnement est contrôlé par l'option OIDC_USE_ID_TOKEN. Lorsqu'elle est activée, le id_token est décodé et ses claims sont utilisés pour construire l'utilisateur. Sinon, le comportement actuel (appel à /userinfo avec l'access_token) est conservé.

Je n'ai testé que l'algorithme RS256 avec une clé publique au format PEM. Le support de HS256 est également présent et devrait fonctionner correctement.

Deux points importants :

Mon serveur CAS (et probablement d'autres IdP) ne fournit pas la clé publique directement au format PEM mais au format JWKS (RSA). J'ai converti cette clé en PEM à l'aide de ce script Python :
https://akrabat.com/converting-jwks-json-to-pem-using-python/

Je n'ai pas réussi à récupérer et convertir automatiquement la clé depuis l'endpoint /jwks en PHP. Cette clé pourrait être récupérée dynamiquement plutôt que configurée manuellement. Ça pourrait faire l'objet d'une amélioration ultérieure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OIDC ID token decoding for user info retrieval.
  * Selectable JWT algorithm (RS256 or HS256) and runtime option to supply verification key/secret.
  * Configuration flags added to enable ID token usage and provide algorithm/key settings.

* **Chores**
  * Added a JWT library dependency to support ID token decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->