### PR TITLE
Fix LDAP login filter incorrect AND/OR grouping with multiple attributes

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -64,15 +64,11 @@ class LoginController extends Controller
             }
 
             // Filtre OR sur les attributs configurés
-            $first = true;
-            foreach ($attrs as $attr) {
-                if ($first) {
-                    $query->whereEquals($attr, $appUsername);
-                    $first = false;
-                } else {
-                    $query->orWhereEquals($attr, $appUsername);
+            $query->where(function ($q) use ($attrs, $appUsername) {
+                foreach ($attrs as $attr) {
+                    $q->orWhereEquals($attr, $appUsername);
                 }
-            }
+            });
 
             // Collision guard
             $results = $query->limit(2)->get();


### PR DESCRIPTION
Fixes #684

The login filter loop used `whereEquals()` for the first attribute and `orWhereEquals()` for the rest, generating an AND between the first attribute and an OR group of the others instead of a single OR group across all attributes. This made multi-attribute LDAP login (`LDAP_LOGIN_ATTRIBUTES` with more than one value) fail even when the LDAP bind itself succeeded.

Wrapped all attributes in a single `where(function ($q) ...)` closure with `orWhereEquals()` calls only, so the filter is a proper single OR group.