### PR TITLE
Fix hardcoded LDAP auto-provision email fallback causing unique constraint violation

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -135,7 +135,7 @@ class LoginController extends Controller
                 if (!$local && $autoProvision) {
                     $local = User::create([
                         'name'     => $ldapUser->getFirstAttribute('cn')   ?: $identifier,
-                        'email'    => $ldapUser->getFirstAttribute('mail') ?: 'user@localhost.local',
+                        'email'    => $ldapUser->getFirstAttribute('mail') ?: $identifier.'@localhost.local',
                         'login'    => $identifier,
                         'role'     => 5,
                         'password' => Hash::make(Str::random(32)), // inutilisable en local par défaut


### PR DESCRIPTION
Fixes #685

When auto-provisioning a new user from LDAP without a "mail" attribute, the fallback email was hardcoded to "user@localhost.local". Since email has a unique constraint on the users table, the first user without "mail" got created fine, but any subsequent one failed with a 500 (duplicate entry).

Changed the fallback to be unique per user, based on their login identifier instead.