### PR TITLE
Track storage/framework and storage/logs skeleton directories

### DIFF
--- a/storage/framework/cache/.gitignore
+++ b/storage/framework/cache/.gitignore
@@ -1,0 +1,3 @@
+*
+!data/
+!.gitignore

--- a/storage/framework/cache/data/.gitignore
+++ b/storage/framework/cache/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/sessions/.gitignore
+++ b/storage/framework/sessions/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/testing/.gitignore
+++ b/storage/framework/testing/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/framework/views/.gitignore
+++ b/storage/framework/views/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/storage/logs/.gitignore
+++ b/storage/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
CI (and any fresh clone) had no storage/framework/{cache,sessions, testing,views} or storage/logs directories, since the top-level /storage gitignore rule excludes them entirely and no placeholder was tracked. Without storage/framework/views existing, Blade's compiler throws "Please provide a valid cache path.", which is why every view-rendering test failed on GitHub Actions.