### PR TITLE
Generate Passport keys in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,10 @@ jobs:
         run: |
           php artisan key:generate
 
+      - name: Generate Passport keys
+        run: |
+          php artisan passport:keys
+
       - name: Publish any publishable assets from vendor packages
         run: |
           php artisan vendor:publish --all


### PR DESCRIPTION
The API tests use auth:api (Laravel Passport), which needs storage/oauth-{private,public}.key to exist. Nothing in CI created them, so league/oauth2-server threw "Invalid key supplied" on every API test.