### PR TITLE
ci: add retry on Docker build/push to handle transient registry timeouts

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -28,14 +28,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: nick-fields/retry@v3
         with:
-          context: .
-          platforms: linux/amd64  # linux/arm64 peut être rajouté plus tard
-          push: true
-          build-args: |
-              APP_VERSION=${{ steps.version.outputs.version }}
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
-            ghcr.io/${{ github.repository }}:latest
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            docker buildx build \
+              --platform linux/amd64 \
+              --push \
+              --build-arg APP_VERSION=${{ steps.version.outputs.version }} \
+              --tag ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }} \
+              --tag ghcr.io/${{ github.repository }}:latest \
+              .


### PR DESCRIPTION
The job failed twice on main (dial tcp timeout resolving php:8.4-fpm-bookworm, and "unknown blob") — both transient Docker Hub/registry errors, unrelated to the code, and both succeeded on the next push. Wrap the build in nick-fields/retry to auto-retry instead of requiring a manual re-run.